### PR TITLE
chore: add SkipDocumentation

### DIFF
--- a/document_test.go
+++ b/document_test.go
@@ -400,3 +400,21 @@ func TestDocument(t *testing.T) {
 	assert.NotEmpty(t, rend)
 	assert.Equal(t, expect, string(rend))
 }
+
+func TestDocumentSkipDocumentation(t *testing.T) {
+	t.Parallel()
+
+	arrest.SkipDocumentation = true
+
+	doc, err := arrest.NewDocument("")
+	require.NotNil(t, doc)
+	require.NoError(t, err)
+
+	err = OpenAPI(doc)
+	assert.NoError(t, err)
+
+	rend, err := doc.OpenAPI.Render()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, rend)
+	assert.Equal(t, expect, string(rend))
+}


### PR DESCRIPTION
This pull request introduces a new feature to optionally skip generating documentation for models, which can significantly improve runtime performance and streamline OpenAPI generation. The most important changes include adding a global `SkipDocumentation` variable, modifying functions to respect this flag, and adding a new test to validate the behavior.

### Feature: Skipping Documentation for Models
* Added a global variable `SkipDocumentation` in `model.go` to allow skipping documentation generation for models, enhancing runtime performance and simplifying OpenAPI specs.

### Code Modifications to Support the Feature
* Updated the `makeSchemaProxy` and related functions (`makeSchemaProxyStruct`, `makeSchemaProxySlice`, `makeSchemaProxyMap`) to accept a `skipDoc` parameter, which determines whether to generate documentation. These functions now respect the `SkipDocumentation` flag. [[1]](diffhunk://#diff-5b0177864e946f50ded814588776996128f6b96cbaec3d79877d7163102bb2c1L86-R98) [[2]](diffhunk://#diff-5b0177864e946f50ded814588776996128f6b96cbaec3d79877d7163102bb2c1L196-R208) [[3]](diffhunk://#diff-5b0177864e946f50ded814588776996128f6b96cbaec3d79877d7163102bb2c1L217-R229) [[4]](diffhunk://#diff-5b0177864e946f50ded814588776996128f6b96cbaec3d79877d7163102bb2c1L236-R247) [[5]](diffhunk://#diff-5b0177864e946f50ded814588776996128f6b96cbaec3d79877d7163102bb2c1L245-R262) [[6]](diffhunk://#diff-5b0177864e946f50ded814588776996128f6b96cbaec3d79877d7163102bb2c1L294-R305)

### Testing
* Added a new test `TestDocumentSkipDocumentation` in `document_test.go` to verify that the `SkipDocumentation` flag correctly disables documentation generation while maintaining valid OpenAPI output.