### PR TITLE
fix(scripts): stage go.mod/go.sum in nested modules in retidy-pr

### DIFF
--- a/scripts/retidy-pr
+++ b/scripts/retidy-pr
@@ -206,8 +206,11 @@ fi
 # Stage all go.mod and go.sum files
 log_info "Staging go.mod and go.sum files..."
 for dir in "${GO_MOD_DIRS[@]}"; do
-    [[ -f "$dir/go.mod" ]] && git add "$dir/go.mod"
-    [[ -f "$dir/go.sum" ]] && git add "$dir/go.sum"
+    for f in go.mod go.sum; do
+        if [[ -f "$dir/$f" ]] || git ls-files --error-unmatch "$dir/$f" >/dev/null 2>&1; then
+            git add -A -- "$dir/$f"
+        fi
+    done
 done
 
 # Check if there are staged changes

--- a/scripts/retidy-pr
+++ b/scripts/retidy-pr
@@ -205,7 +205,10 @@ fi
 
 # Stage all go.mod and go.sum files
 log_info "Staging go.mod and go.sum files..."
-git add */go.mod */go.sum go.mod go.sum 2>/dev/null || true
+for dir in "${GO_MOD_DIRS[@]}"; do
+    [[ -f "$dir/go.mod" ]] && git add "$dir/go.mod"
+    [[ -f "$dir/go.sum" ]] && git add "$dir/go.sum"
+done
 
 # Check if there are staged changes
 if git diff --cached --quiet; then


### PR DESCRIPTION
## Summary
- `scripts/retidy-pr` used `git add */go.mod */go.sum go.mod go.sum`, which only matches depth 0 and 1. Changes produced by `go mod tidy` in deeper modules (e.g. `gin/examples/polymorphic/`) were never staged, so the script reported "No go.mod or go.sum changes to commit" and exited without committing.
- Iterate over the already-discovered `GO_MOD_DIRS` instead, staging each module's `go.mod`/`go.sum` explicitly.

## Test plan
- [x] Ran `./scripts/retidy-pr` against PR #44 (branch `dependabot/go_modules/go.yaml.in/yaml/v4-4.0.0-rc.4`) — prior to the fix it exited without committing; after the fix it committed and pushed the tidy results and posted the PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)